### PR TITLE
mirror: support snapshotting

### DIFF
--- a/rpm_s3_mirror/__main__.py
+++ b/rpm_s3_mirror/__main__.py
@@ -9,22 +9,42 @@ from rpm_s3_mirror.mirror import Mirror
 logging.getLogger("boto").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
-logging.basicConfig(level=logging.DEBUG)
 
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--snapshot",
+        help="Create a snapshot of current repository state",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--verbose",
+        help="Verbose logging",
+        action="store_true",
+        default=False,
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--config", help="Path to config file")
     group.add_argument("--env", help="Read configuration from environment variables", action="store_true")
+
     args = parser.parse_args()
     if args.config:
         config = JSONConfig(path=args.config)
     elif args.env:
         config = ENVConfig()
 
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
     mirror = Mirror(config=config)
-    mirror.sync()
+    if args.snapshot:
+        mirror.snapshot()
+    else:
+        mirror.sync()
 
 
 if __name__ == "__main__":

--- a/rpm_s3_mirror/__main__.py
+++ b/rpm_s3_mirror/__main__.py
@@ -14,20 +14,28 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--snapshot",
-        help="Create a snapshot of current repository state",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
         "--verbose",
         help="Verbose logging",
         action="store_true",
         default=False,
     )
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--config", help="Path to config file")
-    group.add_argument("--env", help="Read configuration from environment variables", action="store_true")
+
+    operation_group = parser.add_mutually_exclusive_group(required=False)
+    operation_group.add_argument(
+        "--snapshot",
+        help="Create a snapshot of current repository state",
+        action="store_true",
+        default=False,
+    )
+    operation_group.add_argument(
+        "--bootstrap",
+        help="Bootstrap an empty s3 mirror",
+        action="store_true",
+        default=False,
+    )
+    config_group = parser.add_mutually_exclusive_group(required=True)
+    config_group.add_argument("--config", help="Path to config file")
+    config_group.add_argument("--env", help="Read configuration from environment variables", action="store_true")
 
     args = parser.parse_args()
     if args.config:
@@ -44,7 +52,7 @@ def main():
     if args.snapshot:
         mirror.snapshot()
     else:
-        mirror.sync()
+        mirror.sync(bootstrap=args.bootstrap)
 
 
 if __name__ == "__main__":

--- a/rpm_s3_mirror/config.py
+++ b/rpm_s3_mirror/config.py
@@ -16,7 +16,6 @@ REQUIRED = {
 DEFAULTS = {
     "scratch_dir": "/var/tmp/",
     "max_workers": 4,
-    "bootstrap": False,
 }
 
 
@@ -32,7 +31,6 @@ class Config:
     scratch_dir = None
     max_workers = None
     upstream_repositories = None
-    bootstrap = None
     _config = DEFAULTS
 
     def __init__(self):
@@ -69,8 +67,6 @@ class ENVConfig(Config):
                 value = value.split(",")
             elif key == "max_workers":
                 value = int(value)
-            elif key == "bootstrap":
-                value = value.lower() == "true"
             self._config[key] = value
 
 

--- a/rpm_s3_mirror/util.py
+++ b/rpm_s3_mirror/util.py
@@ -32,8 +32,7 @@ def get_requests_session() -> Session:
     return session
 
 
-def download_file(self, temp_dir: str, url: str, session: Session = None) -> str:
-    self.log.debug("GET: %s", url)
+def download_file(temp_dir: str, url: str, session: Session = None) -> str:
     session = session or get_requests_session()
     with session.get(url, stream=True) as request:
         request.raise_for_status()

--- a/rpm_s3_mirror/util.py
+++ b/rpm_s3_mirror/util.py
@@ -2,6 +2,9 @@
 
 import datetime
 import hashlib
+import os
+import shutil
+from os.path import join
 
 import requests
 from requests import Session
@@ -9,11 +12,15 @@ from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
 
+def sha256(content):
+    return hashlib.sha256(content).hexdigest()
+
+
 def validate_checksum(path, checksum_type, checksum) -> None:
     if checksum_type != "sha256":
         raise ValueError("Only sha256 checksums are currently supported")
     with open(path, "rb") as f:
-        local_checksum = hashlib.sha256(f.read()).hexdigest()
+        local_checksum = sha256(content=f.read())
         assert checksum == local_checksum, f"{path}: expected {checksum} found {local_checksum}"
 
 
@@ -23,6 +30,17 @@ def get_requests_session() -> Session:
     session.mount("http://", HTTPAdapter(max_retries=retries))
     session.mount("https://", HTTPAdapter(max_retries=retries))
     return session
+
+
+def download_file(self, temp_dir: str, url: str, session: Session = None) -> str:
+    self.log.debug("GET: %s", url)
+    session = session or get_requests_session()
+    with session.get(url, stream=True) as request:
+        request.raise_for_status()
+        out_path = join(temp_dir, os.path.basename(url))
+        with open(out_path, "wb") as f:
+            shutil.copyfileobj(request.raw, f)
+        return out_path
 
 
 def now() -> datetime.datetime:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
 
-from rpm_s3_mirror.repository import Package, PackageList, RPMRepository
+from rpm_s3_mirror.repository import Package, PackageList, RPMRepository, safe_parse_xml
 
 TEST_BASE_URL = "https://some.repo/some/path"
 CHANGED_PACKAGE_NAME = "GMT"
@@ -75,9 +75,10 @@ def test_package_equality(package_list_xml, package_list_changed_xml):
     package_list2 = list(PackageList(base_url=TEST_BASE_URL, packages_xml=package_list_changed_xml))
     assert package_list[1] == package_list2[1]
 
+
 def test_parse_repomd_xml(repomd_xml):
     repository = RPMRepository(base_url=TEST_BASE_URL)
-    repomd = repository.parse_repomd(repomd_xml)
+    repomd = repository.parse_repomd(safe_parse_xml(repomd_xml))
 
     assert list(repomd.keys()) == EXPECTED_REPOMD_KEYS
     assert {k: v.checksum for k, v in repomd.items()} == EXPECTED_REPOMD_CHECKSUMS


### PR DESCRIPTION
Add support for "snapshotting" an RPM repository. This essentially boils down to three steps:
        * rewrite primary.xml to specify a relative location
        * rewrite repomd.xml to update the hashes and point to the new
          location
        * upload these files and other relevant metadata files to the "snapshots/<uuid>" dir in the s3
          bucket

Currently only *.xml.gz files and sha256 hashes are supported.

Usage: point DNF at your snapshot, eg: https://<bucket>.<region>/pub/fedora/linux/releases/31/Everything/x86_64/os/snapshots/91836ecd-89d8-4348-872e-4d22a5809de3/
