### PR TITLE
config: support configuration via Python dict

### DIFF
--- a/rpm_s3_mirror/config.py
+++ b/rpm_s3_mirror/config.py
@@ -78,3 +78,12 @@ class JSONConfig(Config):
     def _populate_required(self):
         with open(self.path) as f:
             self._config.update(json.load(f))
+
+
+class DictConfig(Config):
+    def __init__(self, config_dict):
+        self._config.update(config_dict)
+        super().__init__()
+
+    def _populate_required(self):
+        pass

--- a/rpm_s3_mirror/mirror.py
+++ b/rpm_s3_mirror/mirror.py
@@ -35,7 +35,7 @@ class Mirror:
         )
         self.repositories = [RPMRepository(base_url=url) for url in config.upstream_repositories]
 
-    def sync(self, bootstrap):
+    def sync(self, bootstrap=False):
         start = time.monotonic()
         for upstream_repository in self.repositories:
             mirror_start = time.monotonic()


### PR DESCRIPTION
When using the mirror tool as a library it is convenient to configure it
via a dict.