### PR TITLE
mirror: support named immutable snapshots

### DIFF
--- a/rpm_s3_mirror/__main__.py
+++ b/rpm_s3_mirror/__main__.py
@@ -22,10 +22,7 @@ def main():
 
     operation_group = parser.add_mutually_exclusive_group(required=False)
     operation_group.add_argument(
-        "--snapshot",
-        help="Create a snapshot of current repository state",
-        action="store_true",
-        default=False,
+        "--snapshot", help="Create a named snapshot of current repository state", default=False, type=str
     )
     operation_group.add_argument(
         "--bootstrap",
@@ -50,7 +47,7 @@ def main():
 
     mirror = Mirror(config=config)
     if args.snapshot:
-        mirror.snapshot()
+        mirror.snapshot(snapshot_id=args.snapshot)
     else:
         mirror.sync(bootstrap=args.bootstrap)
 

--- a/rpm_s3_mirror/mirror.py
+++ b/rpm_s3_mirror/mirror.py
@@ -1,21 +1,28 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
 
 import logging
-import uuid
-from os.path import basename, join
+import re
 from tempfile import TemporaryDirectory
 
 import time
 from collections import namedtuple
 from urllib.parse import urlparse
 
+from importlib_metadata import suppress
+
 from rpm_s3_mirror.repository import RPMRepository
-from rpm_s3_mirror.s3 import S3
+from rpm_s3_mirror.s3 import S3, S3DirectoryNotFound
 from rpm_s3_mirror.statsd import StatsClient
-from rpm_s3_mirror.util import get_requests_session, now
+from rpm_s3_mirror.util import get_requests_session, now, get_snapshot_directory, get_snapshot_path
 
 Manifest = namedtuple("Manifest", ["update_time", "upstream_repository", "previous_repomd", "synced_packages"])
 MANIFEST_LOCATION = "manifests"
+
+VALID_SNAPSHOT_REGEX = r"^[A-Za-z0-9_-]+$"
+
+
+class InvalidSnapshotID(ValueError):
+    pass
 
 
 class Mirror:
@@ -101,9 +108,9 @@ class Mirror:
         self.log.info("Synced %s repos in %s seconds", len(self.repositories), time.monotonic() - start)
         self.stats.gauge(metric="s3_mirror_sync_seconds_total", value=time.monotonic() - start)
 
-    def snapshot(self):
-        snapshot_id = uuid.uuid4()
-        self.log.debug("Creating snapshot: %s", snapshot_id)
+    def snapshot(self, snapshot_id):
+        self.log.info("Creating snapshot: %s", snapshot_id)
+        self._validate_snapshot_id(snapshot_id)
         with TemporaryDirectory(prefix=self.config.scratch_dir) as temp_dir:
             for upstream_repository in self.repositories:
                 try:
@@ -115,7 +122,15 @@ class Mirror:
                 except Exception as e:
                     self._try_remove_snapshots(snapshot_id=snapshot_id)
                     raise Exception("Failed to snapshot repositories") from e
-        return snapshot_id
+
+    def _validate_snapshot_id(self, snapshot_id):
+        if not re.match(VALID_SNAPSHOT_REGEX, snapshot_id):
+            raise InvalidSnapshotID(f"Snapshot id must match regex: {VALID_SNAPSHOT_REGEX}")
+        for repository in self.repositories:
+            base_path = repository.path[1:]
+            snapshot_dir = get_snapshot_directory(base_path=base_path, snapshot_id=snapshot_id)
+            if self.s3.exists(prefix=snapshot_dir):
+                raise InvalidSnapshotID(f"Cannot overwrite existing snapshot: {snapshot_dir}")
 
     def _snapshot_repository(self, snapshot_id, temp_dir, upstream_repository):
         self.log.debug("Snapshotting repository: %s", upstream_repository.base_url)
@@ -125,28 +140,23 @@ class Mirror:
         for file_path in snapshot.sync_files:
             self.s3.copy_object(
                 source=file_path,
-                destination=self._snapshot_path(base_path, snapshot_id, file_path),
+                destination=get_snapshot_path(base_path, snapshot_id, file_path),
             )
         for file_path in snapshot.upload_files:
             self.s3.put_object(
                 local_path=file_path,
-                key=self._snapshot_path(base_path, snapshot_id, file_path),
+                key=get_snapshot_path(base_path, snapshot_id, file_path),
             )
 
     def _try_remove_snapshots(self, snapshot_id):
         for repository in self.repositories:
-            snapshot_dir = self._snapshot_directory(base_path=repository.base_url, snapshot_id=snapshot_id)
+            snapshot_dir = get_snapshot_directory(base_path=repository.path, snapshot_id=snapshot_id)
             try:
-                self.s3.delete_subdirectory(subdir=snapshot_dir)
-                self.log.debug("Deleted: %s", snapshot_dir)
-            except:  # pylint: disable=bare-except
-                self.log.warning("Failed to remove snapshot: %s", snapshot_dir)
-
-    def _snapshot_path(self, base_path, snapshot_id, file_path):
-        return join(self._snapshot_directory(base_path, snapshot_id), "repodata", basename(file_path))
-
-    def _snapshot_directory(self, base_path, snapshot_id):
-        return join(base_path, "snapshots", str(snapshot_id))
+                with suppress(S3DirectoryNotFound):
+                    self.s3.delete_subdirectory(subdir=snapshot_dir)
+                    self.log.info("Deleted: %s", snapshot_dir)
+            except Exception as e:  # pylint: disable=broad-except
+                self.log.warning("Failed to remove snapshot: %s - %s", snapshot_dir, e)
 
     def _build_s3_url(self, upstream_repository) -> str:
         dest_path = urlparse(upstream_repository.base_url).path

--- a/rpm_s3_mirror/mirror.py
+++ b/rpm_s3_mirror/mirror.py
@@ -2,13 +2,12 @@
 
 import logging
 import re
+from contextlib import suppress
 from tempfile import TemporaryDirectory
 
 import time
 from collections import namedtuple
 from urllib.parse import urlparse
-
-from importlib_metadata import suppress
 
 from rpm_s3_mirror.repository import RPMRepository
 from rpm_s3_mirror.s3 import S3, S3DirectoryNotFound
@@ -126,6 +125,8 @@ class Mirror:
     def _validate_snapshot_id(self, snapshot_id):
         if not re.match(VALID_SNAPSHOT_REGEX, snapshot_id):
             raise InvalidSnapshotID(f"Snapshot id must match regex: {VALID_SNAPSHOT_REGEX}")
+        elif "\n" in snapshot_id:
+            raise InvalidSnapshotID("Snapshot id cannot contain newlines")
         for repository in self.repositories:
             base_path = repository.path[1:]
             snapshot_dir = get_snapshot_directory(base_path=base_path, snapshot_id=snapshot_id)

--- a/rpm_s3_mirror/repository.py
+++ b/rpm_s3_mirror/repository.py
@@ -174,7 +174,9 @@ class RPMRepository:
 
         sync_files = []
         for section in repodata.values():
-            if section.location.endswith(".xml.gz"):
+            if section.location.endswith(".xml.gz") \
+                    or section.location.endswith("updateinfo.xml.xz") \
+                    or section.location.endswith("modules.yaml.gz"):
                 sync_files.append(urlparse(join(self.base_url, section.location)).path)
         return Snapshot(
             sync_files=sync_files,
@@ -220,7 +222,7 @@ class RPMRepository:
     def _rewrite_repomd(self, repomd_xml, snapshot: SnapshotPrimary):
         for element in repomd_xml.findall("repo:*", namespaces=namespaces):
             # We only support *.xml.gz files currently
-            if element.attrib.get("type", None) not in {"primary", "filelists", "other"}:
+            if element.attrib.get("type", None) not in {"primary", "filelists", "other", "modules", "updateinfo"}:
                 repomd_xml.remove(element)
 
         # Rewrite the XML with correct metadata for our changed primary.xml

--- a/rpm_s3_mirror/util.py
+++ b/rpm_s3_mirror/util.py
@@ -4,7 +4,7 @@ import datetime
 import hashlib
 import os
 import shutil
-from os.path import join
+from os.path import join, basename
 
 import requests
 from requests import Session
@@ -45,3 +45,11 @@ def download_file(temp_dir: str, url: str, session: Session = None) -> str:
 def now() -> datetime.datetime:
     current_time = datetime.datetime.now(datetime.timezone.utc)
     return current_time.replace(microsecond=0)
+
+
+def get_snapshot_path(base_path, snapshot_id, file_path):
+    return join(get_snapshot_directory(base_path, snapshot_id), "repodata", basename(file_path))
+
+
+def get_snapshot_directory(base_path, snapshot_id):
+    return join(base_path, "snapshots", snapshot_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+from rpm_s3_mirror.config import DictConfig
 
 
 def load_resource_xml(filename):
@@ -29,3 +30,16 @@ def package_list_changed_xml():
 @pytest.fixture(name="repomd_xml")
 def repomd_xml():
     return REPOMD_XML
+
+
+@pytest.fixture(name="mirror_config")
+def mirror_config():
+    return DictConfig(
+        config_dict={
+            "aws_access_key_id": "***",
+            "aws_secret_access_key": "***",
+            "bucket_name": "some-bucket",
+            "bucket_region": "ap-southeast-2",
+            "upstream_repositories": ["https://someupstreamrepo/os"]
+        }
+    )

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rpm_s3_mirror.mirror import InvalidSnapshotID, Mirror
+
+
+def test_mirror_rejects_invalid_snapshot_id(mirror_config):
+    mirror = Mirror(config=mirror_config)
+    mirror.s3 = MagicMock()
+    with pytest.raises(InvalidSnapshotID):
+        mirror.snapshot(snapshot_id="not-valid-with!-this+")
+    with pytest.raises(InvalidSnapshotID):
+        mirror.snapshot(snapshot_id="trailingnewline\n")
+    assert not mirror.s3.exists.called

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+import pytest
 
 from rpm_s3_mirror.repository import Package, PackageList, RPMRepository, safe_parse_xml
 
@@ -85,3 +86,8 @@ def test_parse_repomd_xml(repomd_xml):
 
     for repodata_section in repomd.values():
         assert all(attr is not None for attr in repodata_section._asdict().values())
+
+
+def test_reject_http_upstream_repository():
+    with pytest.raises(ValueError):
+        RPMRepository(base_url="http://dangerdanger")


### PR DESCRIPTION
Previously we used a UUID for identifying snapshots. This ensured a unique snapshot on each invocation, however having the ability to provide a named snapshot is useful, so allow this but prevent overwriting an existing name.