### PR TITLE
mirror: simplify manifest storage

### DIFF
--- a/rpm_s3_mirror/util.py
+++ b/rpm_s3_mirror/util.py
@@ -42,8 +42,10 @@ def download_file(temp_dir: str, url: str, session: Session = None) -> str:
         return out_path
 
 
-def now() -> datetime.datetime:
+def now(*, microsecond=False) -> datetime.datetime:
     current_time = datetime.datetime.now(datetime.timezone.utc)
+    if microsecond:
+        return current_time
     return current_time.replace(microsecond=0)
 
 


### PR DESCRIPTION
Storing the manifest in the root of the s3 bucket with a hashed path to
the relevant repomd was overcomplicated and unnecessary. Just store it
in the repo root of the repository that was synced.