### PR TITLE
mirror: add --poll-seconds option to poll mirrors forever

### DIFF
--- a/rpm_s3_mirror/mirror.py
+++ b/rpm_s3_mirror/mirror.py
@@ -46,68 +46,82 @@ class Mirror:
     def sync(self, bootstrap=False):
         """ Sync upstream repositories to our s3 mirror """
         start = time.monotonic()
+        sync_success = True
         for upstream_repository in self.repositories:
-            mirror_start = time.monotonic()
-            update_time = now()
-            upstream_metadata = upstream_repository.parse_metadata()
-
-            if bootstrap:
-                self.log.info("Bootstrapping repository: %s", upstream_repository.base_url)
-                new_packages = upstream_metadata.package_list
-            else:
-                self.log.info("Syncing repository: %s", upstream_repository.base_url)
-                # If the upstream repomd.xml file was updated after the last time we updated our
-                # mirror repomd.xml file then there is probably some work to do.
-                mirror_repository = RPMRepository(base_url=self._build_s3_url(upstream_repository))
-                last_check_time = self.s3.repomd_update_time(base_url=mirror_repository.base_url)
-                if not upstream_repository.has_updates(since=last_check_time):
-                    self.log.info("Skipping repository with no updates since: %s", last_check_time)
-                    continue
-
-                # Extract our metadata and detect any new/updated packages.
-                mirror_metadata = mirror_repository.parse_metadata()
-                new_packages = set(upstream_metadata.package_list).difference(set(mirror_metadata.package_list))
-
-            # Sync our mirror with upstream.
-            if new_packages:
-                self.s3.sync_packages(
-                    base_url=upstream_metadata.base_url,
-                    upstream_repodata=upstream_metadata.repodata,
-                    upstream_packages=new_packages,
-                    # If we are bootstrapping the s3 repo, it is worth checking if the package already exists as if the
-                    # process is interrupted halfway through we would have to do a lot of potentially useless work. Once
-                    # we have completed bootstrapping and are just running a sync we don't benefit from checking as it
-                    # slows things down for no good reason (we expect the packages to be there already and if not
-                    # it is a bug of some kind).
-                    skip_existing=bootstrap
-                )
-
-                # If we are not bootstrapping, store a manifest that describes the changes synced in this run
-                if not bootstrap:
-                    manifest_location = self._build_manifest_location(base_url=upstream_repository.base_url)
-                    repomd_path = join(manifest_location, "repomd.xml")
-                    self.s3.archive_repomd(base_url=upstream_repository.base_url, location=repomd_path)
-                    manifest = Manifest(
-                        update_time=update_time,
-                        upstream_repository=upstream_repository.base_url,
-                        previous_repomd=repomd_path,
-                        synced_packages=[package.to_dict() for package in new_packages],
-                    )
-                    manifest_path = join(manifest_location, "manifest.json")
-                    self.s3.put_manifest(location=manifest_path, manifest=manifest)
-
-                # Finally, overwrite the repomd.xml file to make our changes live
-                self.s3.overwrite_repomd(base_url=upstream_repository.base_url)
-
-            self.log.info("Updated mirror with %s packages", len(new_packages))
-            self.stats.gauge(
-                metric="s3_mirror_sync_seconds",
-                value=time.monotonic() - mirror_start,
-                tags={"repo": upstream_metadata.base_url},
-            )
+            try:
+                self._sync_repository(bootstrap, upstream_repository)
+                self.stats.gauge(metric="s3_mirror_failed", value=0, tags={"repo": upstream_repository.path})
+            except Exception as e:  # pylint: disable=broad-except
+                self.log.exception("Failed to sync: %s", upstream_repository.base_url, exc_info=e)
+                self.stats.gauge(metric="s3_mirror_failed", value=1, tags={"repo": upstream_repository.path})
+                sync_success = False
+                continue
 
         self.log.info("Synced %s repos in %s seconds", len(self.repositories), time.monotonic() - start)
         self.stats.gauge(metric="s3_mirror_sync_seconds_total", value=time.monotonic() - start)
+        return sync_success
+
+    def _sync_repository(self, bootstrap, upstream_repository):
+        mirror_start = time.monotonic()
+        update_time = now()
+        upstream_metadata = upstream_repository.parse_metadata()
+        if bootstrap:
+            self.log.info("Bootstrapping repository: %s", upstream_repository.base_url)
+            new_packages = upstream_metadata.package_list
+        else:
+            self.log.info("Syncing repository: %s", upstream_repository.base_url)
+            # If the upstream repomd.xml file was updated after the last time we updated our
+            # mirror repomd.xml file then there is probably some work to do.
+            mirror_repository = RPMRepository(base_url=self._build_s3_url(upstream_repository))
+            last_check_time = self.s3.repomd_update_time(base_url=mirror_repository.base_url)
+            if not upstream_repository.has_updates(since=last_check_time):
+                self.log.info("Skipping repository with no updates since: %s", last_check_time)
+                self.stats.gauge(
+                    metric="s3_mirror_sync_seconds",
+                    value=time.monotonic() - mirror_start,
+                    tags={"repo": upstream_repository.path},
+                )
+                return
+
+            # Extract our metadata and detect any new/updated packages.
+            mirror_metadata = mirror_repository.parse_metadata()
+            new_packages = set(upstream_metadata.package_list).difference(set(mirror_metadata.package_list))
+        # Sync our mirror with upstream.
+        if new_packages:
+            self.s3.sync_packages(
+                base_url=upstream_metadata.base_url,
+                upstream_repodata=upstream_metadata.repodata,
+                upstream_packages=new_packages,
+                # If we are bootstrapping the s3 repo, it is worth checking if the package already exists as if the
+                # process is interrupted halfway through we would have to do a lot of potentially useless work. Once
+                # we have completed bootstrapping and are just running a sync we don't benefit from checking as it
+                # slows things down for no good reason (we expect the packages to be there already and if not
+                # it is a bug of some kind).
+                skip_existing=bootstrap
+            )
+
+            # If we are not bootstrapping, store a manifest that describes the changes synced in this run
+            if not bootstrap:
+                manifest_location = self._build_manifest_location(base_url=upstream_repository.base_url)
+                repomd_path = join(manifest_location, "repomd.xml")
+                self.s3.archive_repomd(base_url=upstream_repository.base_url, location=repomd_path)
+                manifest = Manifest(
+                    update_time=update_time,
+                    upstream_repository=upstream_repository.base_url,
+                    previous_repomd=repomd_path,
+                    synced_packages=[package.to_dict() for package in new_packages],
+                )
+                manifest_path = join(manifest_location, "manifest.json")
+                self.s3.put_manifest(location=manifest_path, manifest=manifest)
+
+            # Finally, overwrite the repomd.xml file to make our changes live
+            self.s3.overwrite_repomd(base_url=upstream_repository.base_url)
+        self.log.info("Updated mirror with %s packages", len(new_packages))
+        self.stats.gauge(
+            metric="s3_mirror_sync_seconds",
+            value=time.monotonic() - mirror_start,
+            tags={"repo": upstream_repository.path},
+        )
 
     def _build_manifest_location(self, base_url):
         sync_directory = now(microsecond=True).replace(tzinfo=None).isoformat()

--- a/rpm_s3_mirror/s3.py
+++ b/rpm_s3_mirror/s3.py
@@ -66,8 +66,16 @@ class S3:
         with TemporaryDirectory(prefix=self.scratch_dir) as temp_dir:
             self._sync_objects(temp_dir, upstream_packages, skip_existing=skip_existing)
             synced_bytes = sum((package.package_size for package in upstream_packages))
-            self.stats.gauge(metric="s3_mirror_sync_bytes", value=synced_bytes, tags={"repo": base_url})
-            self.stats.gauge(metric="s3_mirror_sync_packages", value=len(upstream_packages), tags={"repo": base_url})
+            self.stats.gauge(
+                metric="s3_mirror_sync_bytes",
+                value=synced_bytes,
+                tags={"repo": urlparse(base_url).path},
+            )
+            self.stats.gauge(
+                metric="s3_mirror_sync_packages",
+                value=len(upstream_packages),
+                tags={"repo": urlparse(base_url).path},
+            )
             self._sync_objects(temp_dir=temp_dir, repo_objects=upstream_repodata.values(), skip_existing=skip_existing)
 
     def overwrite_repomd(self, base_url):


### PR DESCRIPTION
Add a poll mode to allow running forever and submitting metrics for
mirror success or failure. This allows defining alerts based on the
submitted metrics.