### PR TITLE
repository: workaround bug in recent lxml version

### DIFF
--- a/rpm_s3_mirror/repository.py
+++ b/rpm_s3_mirror/repository.py
@@ -170,7 +170,7 @@ class RPMRepository:
         self._rewrite_repomd(repomd_xml=repomd_xml, snapshot=snapshot_primary)
         repomd_xml_path = join(scratch_dir, "repomd.xml")
         with open(repomd_xml_path, "wb+") as out:
-            out.write(tostring(repomd_xml))
+            out.write(tostring(repomd_xml, encoding="utf-8"))
 
         sync_files = []
         for section in repodata.values():
@@ -202,7 +202,7 @@ class RPMRepository:
 
             # Now we have rewritten our XML file the checksums no longer match, so calculate some new ones (along with
             # size etc from above).
-            compressed_xml = gzip.compress(tostring(primary_xml))
+            compressed_xml = gzip.compress(tostring(primary_xml, encoding="utf-8"))
             compressed_sha256 = sha256(compressed_xml)
             compressed_size = len(compressed_xml)
             local_path = f"{temp_dir}/{compressed_sha256}-primary.xml.gz"


### PR DESCRIPTION
Recent versions of lxml have a bug where if no encoding is passed to
to_string, it defaults to ascii, however there is a bug in the code path
that handles ascii encoding -
https://bugs.launchpad.net/lxml/+bug/1873306.

As we are fine with using utf-8, pass it explicitly to avoid the
problematic code path.