### PR TITLE
Fix CI - pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -36,7 +36,8 @@ disable=
     line-too-long,
     no-else-continue,
     no-else-break,
-    import-outside-toplevel
+    import-outside-toplevel,
+    unspecified-encoding
 
 [FORMAT]
 max-line-length=125

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all:
 PYTHON ?= python3
 PYTHON_SOURCE_DIRS = rpm_s3_mirror/ tests/
 PYTEST_ARG ?= -v
-PYLINT=$(shell which pylint 2> /dev/null | which pylint-3)
+PYLINT=$(shell which pylint 2> /dev/null || which pylint-3)
 
 clean:
 	$(RM) -r *.egg-info/ build/ dist/ rpm/

--- a/rpm_s3_mirror/mirror.py
+++ b/rpm_s3_mirror/mirror.py
@@ -68,7 +68,7 @@ class Mirror:
         upstream_metadata = upstream_repository.parse_metadata()
 
         mirror_repository = RPMRepository(base_url=self._build_s3_url(upstream_repository.base_url))
-        bootstrap = False if mirror_repository.exists() else True
+        bootstrap = not mirror_repository.exists()
         if bootstrap:
             self.log.info("Bootstrapping repository: %s", upstream_repository.base_url)
             new_packages = upstream_metadata.package_list

--- a/rpm_s3_mirror/repository.py
+++ b/rpm_s3_mirror/repository.py
@@ -284,7 +284,7 @@ class RPMRepository:
         return sections
 
     def _req(self, method, path, *, json=None, params=None, acceptible_status_code=None, **kwargs) -> Response:
-        acceptible_status_code = acceptible_status_code if acceptible_status_code else {200}
+        acceptible_status_code = acceptible_status_code or {200}
         url = f"{self.base_url}{path}"
         response = method(url, json=json, params=params, **kwargs)
         if response.status_code not in acceptible_status_code:

--- a/rpm_s3_mirror/statsd.py
+++ b/rpm_s3_mirror/statsd.py
@@ -66,6 +66,6 @@ class StatsClient:
                 parts.append(pattern.format(separator, tag, val).encode("utf-8"))
         else:
             for tag, val in send_tags.items():
-                parts.insert(1, ",{}={}".format(tag, val).encode("utf-8"))
+                parts.insert(1, f",{tag}={val}".encode("utf-8"))
 
         self._socket.sendto(b"".join(parts), self._dest_addr)


### PR DESCRIPTION
Github pylint check will return
`make: [Makefile:50: pylint] Error 127 (ignored)`
and pylint check has been skipped because in Makefile $(PYLINT) is an empty string

Fix the Makefile and everything pylint compaints

Disable unspecified-encoding (when open()) because Windows is not our
target platform