### PR TITLE
Cache repomd.xml and use cache when overwrite the repo

### DIFF
--- a/rpm_s3_mirror/repository.py
+++ b/rpm_s3_mirror/repository.py
@@ -143,6 +143,8 @@ Snapshot = namedtuple("Snapshot", ["sync_files", "upload_files"])
 
 
 class RPMRepository:
+    """Upstream repository. This MAY NOT be a S3 bucket."""
+
     def __init__(self, base_url: str):
         if not base_url.startswith("https://"):
             raise ValueError("Only https upstream repositories can be synced from")
@@ -238,7 +240,7 @@ class RPMRepository:
                 location=f"repodata/{basename(local_path)}",
             )
 
-    def _rewrite_repomd(self, repomd_xml, snapshot: SnapshotPrimary):
+    def _rewrite_repomd(self, repomd_xml: Element, snapshot: SnapshotPrimary):
         for element in repomd_xml.findall("repo:*", namespaces=namespaces):
             # We only support *.xml.gz files currently
             if element.attrib.get("type", None) not in {"primary", "filelists", "other", "modules", "updateinfo"}:

--- a/rpm_s3_mirror/s3.py
+++ b/rpm_s3_mirror/s3.py
@@ -78,13 +78,11 @@ class S3:
             )
             self._sync_objects(temp_dir=temp_dir, repo_objects=upstream_repodata.values(), skip_existing=skip_existing)
 
-    def overwrite_repomd(self, base_url):
-        with TemporaryDirectory(prefix=self.scratch_dir) as temp_dir:
-            url = f"{base_url}repodata/repomd.xml"
-            repomd_xml = download_file(temp_dir=temp_dir, url=url, session=self.session)
-            path = urlparse(url).path
-            self.log.info("Overwriting repomd.xml")
-            self.put_object(repomd_xml, path, cache_age=0)
+    def overwrite_repomd(self, repomd_xml_local_path, base_url):
+        url = f"{base_url}repodata/repomd.xml"
+        remote_path = urlparse(url).path
+        self.log.info("Overwriting repomd.xml")
+        self.put_object(repomd_xml_local_path, remote_path, cache_age=0)
 
     def archive_repomd(self, base_url, location):
         self.log.debug("Archiving repomd.xml to %s", location)

--- a/rpm_s3_mirror/util.py
+++ b/rpm_s3_mirror/util.py
@@ -35,6 +35,7 @@ def get_requests_session() -> Session:
 
 
 def download_file(temp_dir: str, url: str, session: Session = None) -> str:
+    """Download a file and return the local path."""
     session = session or get_requests_session()
     try:
         return _download_file(session, temp_dir, url)
@@ -60,7 +61,7 @@ def _escape_s3_url(url: str) -> str:
     )
 
 
-def _download_file(session, temp_dir, url):
+def _download_file(session, temp_dir, url) -> str:
     with session.get(url, stream=True) as request:
         request.raise_for_status()
         out_path = join(temp_dir, os.path.basename(url))


### PR DESCRIPTION
since the sync packages may take a bit time, and repo.xml may have been changed in upstream