### PR TITLE
remove boto3 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-dep-fed:
 		python3-defusedxml \
 		python3-requests \
 		python3-dateutil \
-		python3-boto3 \
+		python3-botocore \
 		python3-lxml
 
 test: copyright lint unittest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 defusedxml
 requests
 python-dateutil
-boto3
+botocore
 lxml

--- a/rpm_s3_mirror.spec
+++ b/rpm_s3_mirror.spec
@@ -11,7 +11,7 @@ BuildRequires:  rpm-build
 Requires:       python3-defusedxml
 Requires:       python3-requests
 Requires:       python3-dateutil
-Requires:       python3-boto3
+Requires:       python3-botocore
 Requires:       python3-lxml
 Requires:       systemd
 Requires:       zchunk

--- a/rpm_s3_mirror/s3.py
+++ b/rpm_s3_mirror/s3.py
@@ -13,7 +13,7 @@ from tempfile import TemporaryDirectory, NamedTemporaryFile
 from typing import Collection, Union, BinaryIO, Dict, Iterable
 from urllib.parse import urlparse
 
-import boto3
+import botocore.session
 import botocore.exceptions
 import time
 
@@ -220,7 +220,8 @@ class S3:
         if self._s3 is None:
             # The boto3 client call is not threadsafe, so only allow calling it from a singe thread at a time
             with lock:
-                self._s3 = boto3.client(
+                botocore_session = botocore.session.get_session()
+                self._s3 = botocore_session.create_client(
                     "s3",
                     region_name=self.bucket_region,
                     aws_access_key_id=self.aws_access_key_id,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "defusedxml",
         "requests",
         "python-dateutil",
-        "boto3",
+        "botocore",
         "lxml",
     ],
     entry_points={


### PR DESCRIPTION
botocore dependency is simpler for the use case of rpm_s3_mirror rather than using the boto3 wrapper. This makes it easier to use rpm_s3_mirror along with other dependencies.