### PR TITLE
Use huge_tree in parser to support large xml files

### DIFF
--- a/rpm_s3_mirror/repository.py
+++ b/rpm_s3_mirror/repository.py
@@ -32,7 +32,7 @@ namespaces = {
 
 
 def safe_parse_xml(xml_bytes: bytes) -> Element:
-    safe_parser = XMLParser(resolve_entities=False)
+    safe_parser = XMLParser(huge_tree=True, resolve_entities=False)
     return fromstring(xml_bytes, parser=safe_parser)
 
 


### PR DESCRIPTION
We've had some issues with syncing f37 repos due to the following error:

```
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]: ERROR:Mirror:Failed to sync: https://dl01.fedoraproject.org/pub/fedora/linux/updates/37/Everything/x86_64/
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]: Traceback (most recent call last):
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "/usr/lib/python3.10/site-packages/rpm_s3_mirror/mirror.py", line 63, in sync
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:     self._sync_repository(upstream_repository)
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "/usr/lib/python3.10/site-packages/rpm_s3_mirror/mirror.py", line 144, in _sync_repository
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:     repodata_files = upstream_repository.strip_metadata(
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "/usr/lib/python3.10/site-packages/rpm_s3_mirror/repository.py", line 312, in strip_metadata
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:     rewritten_section = update_section.strip_to_arches(arches=target_arches)
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "/usr/lib/python3.10/site-packages/rpm_s3_mirror/repository.py", line 175, in strip_to_arches
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:     root = safe_parse_xml(xml_bytes)
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "/usr/lib/python3.10/site-packages/rpm_s3_mirror/repository.py", line 36, in safe_parse_xml
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:     return fromstring(xml_bytes, parser=safe_parser)
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/parser.pxi", line 1896, in lxml.etree._parseMemoryDocument
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/parser.pxi", line 1784, in lxml.etree._parseDoc
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/parser.pxi", line 1141, in lxml.etree._BaseParser._parseDoc
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]:   File "<string>", line 384808
May 09 16:54:05 fedora-prod-mirror-621 rpm_s3_mirror[30]: lxml.etree.XMLSyntaxError: internal error: Huge input lookup, line 384808, column 331
```

The general workaround is to enable `huge_tree=True` on the parser but lxml states some security implications: https://lxml.de/api/lxml.etree.XMLParser-class.html. I figure since our parsing here is limited to XMLs provided by Fedora itself, we should be safe, but it's worth discussing.