### PR TITLE
Support zstd-compressed repositories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "python-dateutil>=2.8.1,<3",
     "botocore>=1.23.50,<2",
     "lxml>=4.6.5,<5",
+    "zstd>=1.5.5.1",
 ]
 
 [project.optional-dependencies]

--- a/rpm_s3_mirror.spec
+++ b/rpm_s3_mirror.spec
@@ -13,6 +13,7 @@ Requires:       python3-requests
 Requires:       python3-dateutil
 Requires:       python3-botocore
 Requires:       python3-lxml
+Requires:       python3-zstd
 Requires:       systemd
 Requires:       zchunk
 


### PR DESCRIPTION
A repository may now be compressed using zstd. Extend support to allow for this, in addition to continuing to support gzip-encoded repositories.