### PR TITLE
Support zstd-compressed repositories, including streaming compression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "python-dateutil>=2.8.1,<3",
     "botocore>=1.23.50,<2",
     "lxml>=4.6.5,<5",
-    "zstd>=1.5.5.1",
+    "zstandard>=0.21.0",
 ]
 
 [project.optional-dependencies]

--- a/rpm_s3_mirror.spec
+++ b/rpm_s3_mirror.spec
@@ -13,7 +13,7 @@ Requires:       python3-requests
 Requires:       python3-dateutil
 Requires:       python3-botocore
 Requires:       python3-lxml
-Requires:       python3-zstd
+Requires:       python3-zstandard
 Requires:       systemd
 Requires:       zchunk
 

--- a/rpm_s3_mirror/repository.py
+++ b/rpm_s3_mirror/repository.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
 import dataclasses
 import lzma
-import zstd
+import zstandard
 import re
 import subprocess
 from abc import abstractmethod
@@ -215,9 +215,9 @@ class XZUpdateInfoSection(UpdateInfoSection):
 
 def decompress(filename: Path | str) -> bytes:
     try:
-        with open(filename, "rb") as f:
-            return zstd.decompress(f.read())
-    except zstd.Error:
+        with zstandard.open(filename) as f:
+            return f.read()
+    except zstandard.ZstdError:
         with gzip.open(filename) as f:
             return f.read()
 


### PR DESCRIPTION
Sometimes a zstd-compressed repository will have used streaming
compression. The simpler zstd package does not support it, so use the
full zstandard package instead.