### PR TITLE
Allow lxml version 5 and newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "requests>=2.27.1,<3",
     "python-dateutil>=2.8.1,<3",
     "botocore>=1.23.50,<2",
-    "lxml>=4.6.5,<5",
+    "lxml>=4.6.5",
     "zstandard>=0.21.0",
 ]
 


### PR DESCRIPTION
lxml 5 is now released and is the default version shipped on Fedora versions 40 and above. The tests still pass if we use this version, and there is nothing in the changelog that sounds like it would break our usage, so removing this version constraint.