### PR TITLE
Actually run CI and make it pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Python package
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,6 @@ jobs:
 
     - name: Tests
       run: |
+        sudo apt install zchunk
         pip install pytest
         make unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Linting with pylint
       run: |
-        pip install pytest pylint pylint-quotes
+        pip install pytest pylint
         make pylint
 
     - name: Tests

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,15 +1,8 @@
 [MASTER]
-load-plugins=pylint_quotes
-
-string-quote=double-avoid-escape
-triple-quote=double
-docstring-quote=double
 
 [MESSAGES CONTROL]
 disable=
     abstract-method,
-    bad-continuation,
-    bad-whitespace,  # Black deals with whitespace around operators and brackets
     chained-comparison,  # R1716: Simplify chained comparison between the operands
     duplicate-code,
     fixme,
@@ -18,7 +11,6 @@ disable=
     missing-docstring,
     no-else-return,
     no-else-raise,
-    no-self-use,
     superfluous-parens,
     too-few-public-methods,
     too-many-ancestors,

--- a/rpm_s3_mirror/__main__.py
+++ b/rpm_s3_mirror/__main__.py
@@ -57,6 +57,9 @@ def main():
         config = JSONConfig(path=args.config)
     elif args.env:
         config = ENVConfig()
+    else:
+        print("Must provide either --config or --env")
+        sys.exit(1)
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)

--- a/rpm_s3_mirror/mirror.py
+++ b/rpm_s3_mirror/mirror.py
@@ -184,7 +184,7 @@ class Mirror:
                     )
                 except Exception as e:
                     self._try_remove_snapshots(snapshot_id=snapshot_id)
-                    raise Exception("Failed to snapshot repositories") from e
+                    raise Exception("Failed to snapshot repositories") from e  # pylint: disable=broad-exception-raised
 
     def list_snapshots(self):
         snapshots = defaultdict(dict)

--- a/rpm_s3_mirror/s3.py
+++ b/rpm_s3_mirror/s3.py
@@ -37,6 +37,7 @@ class S3DirectoryNotFound(Exception):
 class S3:
     def __init__(
         self,
+        *,
         aws_access_key_id: str,
         aws_secret_access_key: str,
         bucket_name: str,

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -118,8 +118,12 @@ def test_decompress(content: bytes, expected: bytes):
 @pytest.mark.parametrize(
     ["filename", "expected_open_checksum"],
     [
-        pytest.param("example-updateinfo.xml.zst", "79201820d67e2e0d02f76842c8eaa0319e2eb1bdc84e24a06edbd0eb0923ec20", id="zstd"),
-        pytest.param("example-updateinfo.xml.zck", "79201820d67e2e0d02f76842c8eaa0319e2eb1bdc84e24a06edbd0eb0923ec20", id="zck"),
+        pytest.param(
+            "example-updateinfo.xml.zst", "79201820d67e2e0d02f76842c8eaa0319e2eb1bdc84e24a06edbd0eb0923ec20", id="zstd"
+        ),
+        pytest.param(
+            "example-updateinfo.xml.zck", "79201820d67e2e0d02f76842c8eaa0319e2eb1bdc84e24a06edbd0eb0923ec20", id="zck"
+        ),
     ],
 )
 def test_rewrite_updateinfo(filename: str, expected_open_checksum: str):


### PR DESCRIPTION
CI has been broken for a while. Make sure it runs, and fix all the failures that have been introduced, and update to run for more recent Python versions. We should probably replace most of the CI linting/formatting stuff with ruff, but for now the simplest thing is to fix pylint:

- remove broken and unsupported extension `pylint-quotes`
- remove deprecated/removed config options from `.pylintrc`
- fix linting error related to passing in config
- fix linting error for too many positional arguments to S3 class - we only call this once and we pass all keyword arguments so all good
- ignore broad exception raised.
